### PR TITLE
add entry to get local issue types

### DIFF
--- a/controllers/issue.go
+++ b/controllers/issue.go
@@ -542,6 +542,21 @@ type IssueTypeResponse struct {
 }
 
 func (c *TypesController) Get() {
+	mode := c.GetString("mode", "")
+	if mode == "local" {
+		var issue []models.Issue
+		o := orm.NewOrm()
+		searchSql := "select distinct issue_type from issue"
+		_, err := o.Raw(searchSql).QueryRows(&issue)
+		if err != nil {
+			logs.Error("Fail to search issue types, err:", err)
+		}
+		res := make([]string, 0)
+		for _, i := range issue {
+			res = append(res, i.IssueType)
+		}
+		c.ApiJsonReturn("请求成功", 200, res)
+	}
 	token := models.GetV8Token(3)
 	enterpriseId := os.Getenv("EnterpriseId")
 	url := fmt.Sprintf("https://api.gitee.com/enterprises/%s/issue_types?page=1&per_page=100&access_token=%s", enterpriseId, token)


### PR DESCRIPTION
扩展/issues/type接口，通过参数model=local获取本地所有issue的issue_type，使issue看板页面对后台的数据请求更快速、稳定