### PR TITLE
optimize query sql and persistence labels colors

### DIFF
--- a/controllers/hook.go
+++ b/controllers/hook.go
@@ -92,6 +92,27 @@ func HandleIssueEvent(reqBody map[string]interface{}) {
 	tags := make([]string, 0)
 	if labels != nil {
 		for _, label := range labels.([]interface{}) {
+			var lb models.Label
+			lb.Name = label.(map[string]interface{})["name"].(string)
+			lb.Color = label.(map[string]interface{})["color"].(string)
+			lb.UniqueId = label.(map[string]interface{})["id"].(float64)
+			if models.SearchLabel(lb.Name) {
+				o := orm.NewOrm()
+				qs := o.QueryTable("label")
+				_, err = qs.Filter("name", lb.Name).Update(orm.Params{
+					"color":     lb.Color,
+					"unique_id": lb.UniqueId,
+				})
+				if err != nil {
+					logs.Error("Update label failed, err:", err)
+				}
+			} else {
+				o := orm.NewOrm()
+				_, err = o.Insert(&lb)
+				if err != nil {
+					logs.Error("Insert label failed, err:", err)
+				}
+			}
 			tags = append(tags, label.(map[string]interface{})["name"].(string))
 		}
 	}
@@ -212,6 +233,27 @@ func HandlePullEvent(reqBody map[string]interface{}) {
 	assigneesSlice := make([]string, 0)
 	if labels != nil {
 		for _, label := range labels.([]interface{}) {
+			var lb models.Label
+			lb.Name = label.(map[string]interface{})["name"].(string)
+			lb.Color = label.(map[string]interface{})["color"].(string)
+			lb.UniqueId = label.(map[string]interface{})["id"].(float64)
+			if models.SearchLabel(lb.Name) {
+				o := orm.NewOrm()
+				qs := o.QueryTable("label")
+				_, err = qs.Filter("name", lb.Name).Update(orm.Params{
+					"color":     lb.Color,
+					"unique_id": lb.UniqueId,
+				})
+				if err != nil {
+					logs.Error("Update label failed, err:", err)
+				}
+			} else {
+				o := orm.NewOrm()
+				_, err = o.Insert(&lb)
+				if err != nil {
+					logs.Error("Insert label failed, err:", err)
+				}
+			}
 			labelsSlice = append(labelsSlice, label.(map[string]interface{})["name"].(string))
 		}
 	}

--- a/controllers/issue.go
+++ b/controllers/issue.go
@@ -137,15 +137,16 @@ func formQueryIssueSql(q QueryIssueParam) (int64, string) {
 	} else {
 		rawSql += fmt.Sprintf(" order by %s desc", sort)
 	}
-	var issue []models.Issue
 	o := orm.NewOrm()
-	count, _ := o.Raw(rawSql).QueryRows(&issue)
+	countSql := strings.Replace(rawSql, "*", "count(*)", -1)
+	var sqlCount int
+	_ = o.Raw(countSql).QueryRow(&sqlCount)
 	if perPage >= 100 {
 		perPage = 100
 	}
 	offset := perPage * (page - 1)
 	rawSql += fmt.Sprintf(" limit %v offset %v", perPage, offset)
-	return count, rawSql
+	return int64(sqlCount), rawSql
 }
 
 func (c *IssuesController) Get() {

--- a/controllers/pull.go
+++ b/controllers/pull.go
@@ -100,12 +100,13 @@ func formQueryPullSql(q QueryPullParam) (int64, string) {
 	} else {
 		rawSql += fmt.Sprintf(" order by %s desc", order)
 	}
-	var pull []models.Pull
 	o := orm.NewOrm()
-	count, _ := o.Raw(rawSql).QueryRows(&pull)
+	countSql := strings.Replace(rawSql, "*", "count(*)", -1)
+	var sqlCount int
+	_ = o.Raw(countSql).QueryRow(&sqlCount)
 	offset := perPage * (page - 1)
 	rawSql += fmt.Sprintf(" limit %v offset %v", perPage, offset)
-	return count, rawSql
+	return int64(sqlCount), rawSql
 }
 
 func (c *PullsController) Get() {

--- a/models/label.go
+++ b/models/label.go
@@ -1,0 +1,23 @@
+package models
+
+import (
+	"fmt"
+	"github.com/astaxie/beego/orm"
+)
+
+type Label struct {
+	Id       int     `json:"-"`
+	Name     string  `json:"name"`
+	Color    string  `json:"color"`
+	UniqueId float64 `json:"-"`
+}
+
+func SearchLabel(name string) bool {
+	o := orm.NewOrm()
+	searchSql := fmt.Sprintf("select * from label where name='%s'", name)
+	err := o.Raw(searchSql).QueryRow()
+	if err == orm.ErrNoRows {
+		return false
+	}
+	return true
+}

--- a/models/pull.go
+++ b/models/pull.go
@@ -6,6 +6,10 @@ import (
 	"github.com/astaxie/beego/logs"
 	"github.com/astaxie/beego/orm"
 	_ "github.com/go-sql-driver/mysql"
+	"io/ioutil"
+	"issue_pr_board/utils"
+	"net/http"
+	"os"
 )
 
 type Pull struct {
@@ -38,10 +42,49 @@ func init() {
 		logs.Error("Fail to register database, err:", err)
 		return
 	}
-	orm.RegisterModel(new(Pull), new(Issue), new(Repo), new(Secret), new(Verify))
+	orm.RegisterModel(new(Pull), new(Issue), new(Repo), new(Secret), new(Verify), new(Label))
 	err = orm.RunSyncdb("default", false, true)
 	if err != nil {
 		logs.Error("Fail to sync databases, err:", err)
 		return
+	}
+	url := fmt.Sprintf("https://gitee.com/api/v5/enterprises/open_euler/labels?access_token=%v", os.Getenv("AccessToken"))
+	resp, err := http.Get(url)
+	if err != nil {
+		logs.Error("Fail to get enterprise labels colors, err：", err)
+	}
+	if resp.StatusCode != 200 {
+		logs.Error("Get unexpected response when getting enterprise labels colors, status:", resp.Status)
+	}
+	body, _ := ioutil.ReadAll(resp.Body)
+	err = resp.Body.Close()
+	if err != nil {
+		logs.Error("Fail to close response body of enterprise issues, err:", err)
+	}
+	if len(string(body)) == 2 {
+	}
+	labels := utils.JsonToSlice(string(body))
+	for _, i := range labels {
+		var lb Label
+		lb.Name = i["name"].(string)
+		lb.Color = i["color"].(string)
+		lb.UniqueId = i["id"].(float64)
+		if SearchLabel(lb.Name) {
+			o := orm.NewOrm()
+			qs := o.QueryTable("label")
+			_, err = qs.Filter("name", lb.Name).Update(orm.Params{
+				"color":     lb.Color,
+				"unique_id": lb.UniqueId,
+			})
+			if err != nil {
+				logs.Error("Update label failed, err:", err)
+			}
+		} else {
+			o := orm.NewOrm()
+			_, err = o.Insert(&lb)
+			if err != nil {
+				logs.Error("Insert label failed, err:", err)
+			}
+		}
 	}
 }

--- a/sync.go
+++ b/sync.go
@@ -77,6 +77,27 @@ func SyncEnterprisePulls() error {
 			assigneesSlice := make([]string, 0)
 			if labels != nil {
 				for _, label := range labels.([]interface{}) {
+					var lb models.Label
+					lb.Name = label.(map[string]interface{})["name"].(string)
+					lb.Color = label.(map[string]interface{})["color"].(string)
+					lb.UniqueId = label.(map[string]interface{})["id"].(float64)
+					if models.SearchLabel(lb.Name) {
+						o := orm.NewOrm()
+						qs := o.QueryTable("label")
+						_, err = qs.Filter("name", lb.Name).Update(orm.Params{
+							"color":     lb.Color,
+							"unique_id": lb.UniqueId,
+						})
+						if err != nil {
+							logs.Error("Update label failed, err:", err)
+						}
+					} else {
+						o := orm.NewOrm()
+						_, err = o.Insert(&lb)
+						if err != nil {
+							logs.Error("Insert label failed, err:", err)
+						}
+					}
 					labelsSlice = append(labelsSlice, label.(map[string]interface{})["name"].(string))
 				}
 			}
@@ -206,6 +227,27 @@ func SyncEnterpriseIssues() error {
 			tags := make([]string, 0)
 			if labels != nil {
 				for _, label := range labels.([]interface{}) {
+					var lb models.Label
+					lb.Name = label.(map[string]interface{})["name"].(string)
+					lb.Color = label.(map[string]interface{})["color"].(string)
+					lb.UniqueId = label.(map[string]interface{})["id"].(float64)
+					if models.SearchLabel(lb.Name) {
+						o := orm.NewOrm()
+						qs := o.QueryTable("label")
+						_, err = qs.Filter("name", lb.Name).Update(orm.Params{
+							"color":     lb.Color,
+							"unique_id": lb.UniqueId,
+						})
+						if err != nil {
+							logs.Error("Update label failed, err:", err)
+						}
+					} else {
+						o := orm.NewOrm()
+						_, err = o.Insert(&lb)
+						if err != nil {
+							logs.Error("Insert label failed, err:", err)
+						}
+					}
 					tags = append(tags, label.(map[string]interface{})["name"].(string))
 				}
 			}


### PR DESCRIPTION
1. 优化/issues和/pulls两个接口的count计算，缩短耗时
2. 新增label表，持久化存储/刷新标签数据